### PR TITLE
hunterize w/ cmake updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,168 @@
-sudo: required
-dist: trusty
+# source: https://raw.githubusercontent.com/ingenue/hunter/pkg.template/.travis.yml
 
-language: cpp
+# OSX/Linux (https://github.com/travis-ci-tester/toolchain-table)
 
-compiler:
-  - g++
+# Workaround for https://github.com/travis-ci/travis-ci/issues/8363
+language:
+  - minimal
 
+# Container-based infrastructure (Linux)
+# * https://docs.travis-ci.com/user/migrating-from-legacy/#How-can-I-use-container-based-infrastructure%3F
+sudo:
+  - false
+
+# Install packages differs for container-based infrastructure
+# * https://docs.travis-ci.com/user/migrating-from-legacy/#How-do-I-install-APT-sources-and-packages%3F
 addons:
   apt:
     sources:
-    - ubuntu-toolchain-r-test
+      - ubuntu-toolchain-r-test
+      - llvm-toolchain-trusty-5.0
     packages:
-    - cmake
-    - libprotobuf-dev
-    - protobuf-compiler
+      - python3-pip
+
+      - g++-5
+      - gcc-5
+
+dist:
+  - trusty
+
+matrix:
+  include:
+    # Linux {
+
+    - os: linux
+      env: CONFIG=Release TOOLCHAIN=clang-cxx17
+
+    # FIXME: https://travis-ci.org/xsacha/hunter/jobs/347083573
+    # - os: linux
+    #   env: CONFIG=Release TOOLCHAIN=gcc-7-cxx17 
+
+    - os: linux
+      env: CONFIG=Release TOOLCHAIN=android-ndk-r16b-api-24-arm64-v8a-clang-libcxx14 
+
+    # FIXME (TIFF broken)
+    # * https://travis-ci.org/ingenue/hunter/jobs/116592968
+    # - os: linux
+    #   env: CONFIG=Release TOOLCHAIN=analyze-cxx17
+
+    - os: linux
+      env: CONFIG=Release TOOLCHAIN=sanitize-address-cxx17
+
+    - os: linux
+      env: CONFIG=Release TOOLCHAIN=sanitize-leak-cxx17
+
+    - os: linux
+      env: CONFIG=Release TOOLCHAIN=sanitize-thread-cxx17 
+
+    # }
+
+    # OSX {
+
+    - os: osx
+      osx_image: xcode9.2
+      env: CONFIG=Release TOOLCHAIN=osx-10-13-make-cxx14
+
+    - os: osx
+      osx_image: xcode9.2
+      env: CONFIG=Release TOOLCHAIN=osx-10-13-cxx14 
+
+    # Upload from local machine
+    # FIXME: modules/core/src/parallel_impl.cpp:396:21: error: implicitly declaring library function '_mm_pause' with type 'void ()'
+    # - os: osx
+    #   osx_image: xcode9.2
+    #   env: CONFIG=Release TOOLCHAIN=ios-nocodesign-11-2-dep-9-3 
+
+    # }
+
+    # OpenCV-extra {
+
+    # Linux {
+
+    - os: linux
+      env: CONFIG=Release-extra TOOLCHAIN=clang-cxx17 
+
+    # FIXME: https://travis-ci.org/xsacha/hunter/jobs/347083589
+    # - os: linux
+    #   env: CONFIG=Release-extra TOOLCHAIN=gcc-7-cxx17
+
+    - os: linux
+      env: CONFIG=Release-extra TOOLCHAIN=android-ndk-r16b-api-24-arm64-v8a-clang-libcxx14 
+
+    # FIXME (TIFF broken)
+    # * https://travis-ci.org/ingenue/hunter/jobs/116592968
+    # - os: linux
+    #   env: CONFIG=Release-extra TOOLCHAIN=analyze-cxx17
+
+    - os: linux
+      env: CONFIG=Release-extra TOOLCHAIN=sanitize-address-cxx17 
+
+    - os: linux
+      env: CONFIG=Release-extra TOOLCHAIN=sanitize-leak-cxx17 
+
+    - os: linux
+      env: CONFIG=Release-extra TOOLCHAIN=sanitize-thread-cxx17 
+
+    # }
+
+    # OSX {
+
+    - os: osx
+      osx_image: xcode9.2
+      env: CONFIG=Release-extra TOOLCHAIN=osx-10-13-make-cxx14
+
+    - os: osx
+      osx_image: xcode9.2
+      env: CONFIG=Release-extra TOOLCHAIN=osx-10-13-cxx14 
+
+    # Upload from local machine
+    # FIXME: modules/core/src/parallel_impl.cpp:396:21: error: implicitly declaring library function '_mm_pause' with type 'void ()'
+    # - os: osx
+    #   osx_image: xcode9.2
+    #   env: CONFIG=Release-extra TOOLCHAIN=ios-nocodesign-11-2-dep-9-3 
+
+    # }
+
+    # }
+
+    # Extra {
+
+    # FIXME: https://travis-ci.org/xsacha/hunter/jobs/347083580
+    # - os: linux
+    #   env: CONFIG=Release-Qt TOOLCHAIN=gcc-7-cxx17 
+
+    - os: osx
+      osx_image: xcode9.2
+      env: CONFIG=Release TOOLCHAIN=ios-nocodesign-11-2-dep-9-3-armv7 
+
+    - os: osx
+      osx_image: xcode9.2
+      env: CONFIG=Release TOOLCHAIN=ios-nocodesign-11-2-dep-9-3-arm64 
+
+    - os: osx
+      osx_image: xcode9.2
+      env: CONFIG=Release-extra TOOLCHAIN=ios-nocodesign-11-2-dep-9-3-armv7 
+
+    # Upload from local machine
+    - os: osx
+      osx_image: xcode9.2
+      env: CONFIG=Release-extra TOOLCHAIN=ios-nocodesign-11-2-dep-9-3-arm64 
+
+    # }
+
+
+install:
+  - source bin/hunter_env.sh
 
 script:
-  - mkdir build
-  - cd build
-  - cmake ..
-  - make
+  - polly.py --toolchain ${TOOLCHAIN} --config ${CONFIG} --verbose --fwd HUNTER_SUPPRESS_LIST_OF_FILES=ON NCNN_LOCAL_TOOLCHAIN=OFF ${TEST} --install --discard 10 --tail 200
+  
+# https://docs.travis-ci.com/user/customizing-the-build/#Whitelisting-or-blacklisting-branches
+# Exclude branch 'pkg.template'. Nothing to build there.
+branches:
+  except:
+    - pkg.template
+    - /^pr\..*/
+    - /^v[0-9]+\.[0-9]+\.[0-9]+$/
+
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,66 +1,45 @@
+cmake_minimum_required(VERSION 3.0.0)
 
-if(CMAKE_TOOLCHAIN_FILE)
-set(LIBRARY_OUTPUT_PATH_ROOT ${CMAKE_BINARY_DIR} CACHE PATH "root for library output, set this to change where android libs are compiled to")
-# get absolute path, but get_filename_component ABSOLUTE only refer with source dir, so find_file here :(
-get_filename_component(CMAKE_TOOLCHAIN_FILE_NAME ${CMAKE_TOOLCHAIN_FILE} NAME)
-find_file(CMAKE_TOOLCHAIN_FILE ${CMAKE_TOOLCHAIN_FILE_NAME} PATHS ${CMAKE_SOURCE_DIR} NO_DEFAULT_PATH)
-message(STATUS "CMAKE_TOOLCHAIN_FILE = ${CMAKE_TOOLCHAIN_FILE}")
-endif()
+include(cmake/hunter.cmake) # huntergate
 
-if(NOT DEFINED CMAKE_INSTALL_PREFIX)
-set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "Installation Directory")
-endif()
-message(STATUS "CMAKE_INSTALL_PREFIX = ${CMAKE_INSTALL_PREFIX}")
-
-project(ncnn)
-
-cmake_minimum_required(VERSION 2.8.10)
-
-# set(CMAKE_BUILD_TYPE debug)
-# set(CMAKE_BUILD_TYPE relwithdebinfo)
-set(CMAKE_BUILD_TYPE release)
+project(ncnn VERSION 2018.03.14)
 
 option(NCNN_OPENMP "openmp support" ON)
 option(NCNN_STDIO "load model from external file" ON)
 option(NCNN_STRING "plain and verbose string" ON)
 option(NCNN_OPENCV "minimal opencv structure emulation" OFF)
 option(NCNN_BENCHMARK "print benchmark information for every layer" OFF)
+option(NCNN_BUILD_EXAMPLES "build ncnn examples" OFF)
+option(NCNN_BUILD_BENCHMARK "build the benchmarks" OFF)
+option(NCNN_BUILD_TOOLS "build ncnn tools" OFF)
+option(NCNN_LOCAL_TOOLCHAIN "use internal default compiler flags" ON)
 
 if(NCNN_OPENMP)
-    find_package(OpenMP)
-    if(OpenMP_CXX_FOUND OR OPENMP_FOUND)
+    find_package(OpenMP) # >= 3.0 for 'collapse'
+    if((OpenMP_CXX_FOUND OR OPENMP_FOUND) AND OpenMP_CXX_VERSION_MAJOR GREATER_EQUAL 3.0)
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
     endif()
 endif()
 
-add_definitions(-Wall -Wextra -Wno-unused-function)
-
-add_definitions(-fPIC)
-add_definitions(-Ofast)
-
-add_definitions(-ffast-math)
-# add_definitions(-march=native)
-
-# add_definitions(-flto)
-
-add_definitions(-fvisibility=hidden -fvisibility-inlines-hidden)
-
-if(ANDROID)
-    # disable shared library on android
-    set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS FALSE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -fno-exceptions")
-elseif(IOS)
-    # disable shared library on xcode ios
-    set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS FALSE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -fno-exceptions")
+if(NCNN_LOCAL_TOOLCHAIN)
+  include(cmake/toolchain.cmake)
 endif()
 
-##############################################
+set(NCNN_TOP_DIR "${CMAKE_CURRENT_LIST_DIR}")
 
-# add_subdirectory(examples)
-# add_subdirectory(benchmark)
+set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
+
 add_subdirectory(src)
-if(NOT ANDROID AND NOT IOS)
-add_subdirectory(tools)
+
+if(NCNN_BUILD_EXAMPLES)
+  add_subdirectory(examples)
+endif()
+
+if(NCNN_BUILD_BENCHMARK)
+  add_subdirectory(benchmark)
+endif()
+
+if(NCNN_BUILD_TOOLS AND NOT ANDROID AND NOT IOS)
+  add_subdirectory(tools)
 endif()

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,29 @@
+# Source: https://raw.githubusercontent.com/ingenue/hunter/pkg.opencv/appveyor.yml
+
+image: Visual Studio 2015
+
+environment:
+
+  matrix:
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      TOOLCHAIN: "vs-14-2015-sdk-8-1"
+      CONFIG: Release
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      TOOLCHAIN: "vs-14-2015"
+      CONFIG: Release
+
+install:
+  - cmd: bin\hunter_env.cmd
+  
+build_script:
+  - cmd: python %POLLY_ROOT%\bin\polly.py --toolchain "%TOOLCHAIN%" --config "%CONFIG%" --verbose --fwd HUNTER_SUPPRESS_LIST_OF_FILES=ON NCNN_LOCAL_TOOLCHAIN=OFF --install --discard 10 --tail 200
+
+# http://www.appveyor.com/docs/branches#white-and-blacklisting
+# Exclude branch 'pkg.template'. Nothing to build there.
+branches:
+  except:
+    - pkg.template
+    - /^pr\..*/
+    - /^v[0-9]+\.[0-9]+\.[0-9]+$/

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,7 +1,3 @@
-
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../src)
-include_directories(${CMAKE_CURRENT_BINARY_DIR}/../src)
-
 add_executable(benchncnn benchncnn.cpp)
 set_property(TARGET benchncnn PROPERTY COMPILE_FLAGS "-fpie")
 set_property(TARGET benchncnn PROPERTY LINK_FLAGS "-pie")

--- a/bin/hunter_env.cmd
+++ b/bin/hunter_env.cmd
@@ -1,0 +1,38 @@
+:: Name: hunter_env.cmd
+:: Purpose: Polly + cmake installation for hunter development
+:: Copyright 2017 Elucideye, Inc.
+::
+:: Source: https://github.com/ingenue/hunter/blob/pkg.template/appveyor.yml
+
+:: Python 3
+set PATH=C:\Python34-x64;C:\Python34-x64\Scripts;%PATH%
+
+:: Install Python package 'requests'
+pip install requests
+
+:: Install latest Polly toolchains and scripts
+appveyor DownloadFile https://github.com/ruslo/polly/archive/master.zip
+7z x master.zip
+set POLLY_ROOT=%cd%\polly-master
+
+:: Install dependencies (CMake, Ninja)
+python %POLLY_ROOT%\bin\install-ci-dependencies.py
+
+:: Tune locations
+set PATH=%cd%\_ci\cmake\bin;%PATH%
+set PATH=%cd%\_ci\ninja;%PATH%
+
+:: Add '--quiet' to avoid leaking the token to logs
+git submodule update --init --recursive --quiet
+
+:: Remove entry with sh.exe from PATH to fix error with MinGW toolchain
+:: (For MinGW make to work correctly sh.exe must NOT be in your path)
+:: * http://stackoverflow.com/a/3870338/2288008
+set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
+
+:: Use MinGW from Qt tools because version is higher
+:: * http://www.appveyor.com/docs/installed-software#qt
+set MINGW_PATH=C:\Qt\Tools\mingw492_32\bin
+
+:: MSYS2 location
+set MSYS_PATH=C:\msys64\usr\bin

--- a/bin/hunter_env.sh
+++ b/bin/hunter_env.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+#
+# Source: https://github.com/ruslo/hunter/blob/master/.travis.yml
+#
+# Download the latest polly release, install and use install-ci-dependencies.py
+# to install a recent CMake that is compatible with Hunter (has CURL, etc).
+# This script supports CI builds but can also be used to configure a functional
+# Hunter build environment on a host machine for standard development.
+
+if [ -z "${CI}" ]; then
+
+    # Usage: travis_retry <flaky_command>
+    # https://github.com/t-richards/dotfiles/blob/master/.bash-functions
+    function travis_retry {
+        local result=0
+        local count=1
+        while [ $count -le 3 ]; do
+            [ $result -ne 0 ] && {
+                echo -e "\n\033[33;1mThe command \"$@\" failed. Retrying, $count of 3.\033[0m\n" >&2
+            }
+            "$@"
+            result=$?
+            [ $result -eq 0 ] && break
+            count=$(($count + 1))
+            sleep 1
+        done
+        
+        [ $count -eq 3 ] && {
+            echo "\n\033[33;1mThe command \"$@\" failed 3 times.\033[0m\n" >&2
+        }
+        return $result
+    }
+fi
+
+# Add '--quiet' to avoid leaking the token to logs
+git submodule update --init --recursive --quiet
+
+# Info about OS
+uname -a
+
+# Disable autoupdate
+# * https://github.com/Homebrew/brew/blob/7d31a70373edae4d8e78d91a4cbc05324bebc3ba/Library/Homebrew/manpages/brew.1.md.erb#L202
+export HOMEBREW_NO_AUTO_UPDATE=1
+
+# Install Python 3
+if [[ "$(uname)" == "Darwin" ]] && [ ! $(which python3) ]; then travis_retry brew install python3; fi
+
+# Install Python package 'requests'
+# 'easy_install3' is not installed by 'brew install python3' on OS X 10.9 Maverick
+if [[ "$(uname)" == "Darwin" ]]; then pip3 install requests; fi
+if [[ "$(uname)" == "Linux" ]]; then travis_retry pip3 install --user requests; fi
+
+# Install latest Polly toolchains and scripts
+wget https://github.com/ruslo/polly/archive/master.zip
+unzip -o master.zip
+POLLY_ROOT="${PWD}/polly-master"
+export PATH="${POLLY_ROOT}/bin:${PATH}"
+
+# Install dependencies (CMake, Android NDK)
+install-ci-dependencies.py
+
+# Tune locations
+export PATH="${PWD}/_ci/cmake/bin:${PATH}"
+
+# Installed if toolchain is Android (otherwise directory doesn't exist)
+export ANDROID_NDK_r10e="`pwd`/_ci/android-ndk-r10e"
+export ANDROID_NDK_r11c="`pwd`/_ci/android-ndk-r11c"
+export ANDROID_NDK_r15c="`pwd`/_ci/android-ndk-r15c"
+export ANDROID_NDK_r16b="`pwd`/_ci/android-ndk-r16b"

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,6 @@
+@PACKAGE_INIT@
+
+find_package(Threads REQUIRED)
+
+include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/cmake/HunterGate.cmake
+++ b/cmake/HunterGate.cmake
@@ -1,0 +1,543 @@
+# Copyright (c) 2013-2017, Ruslan Baratov
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This is a gate file to Hunter package manager.
+# Include this file using `include` command and add package you need, example:
+#
+#     cmake_minimum_required(VERSION 3.0)
+#
+#     include("cmake/HunterGate.cmake")
+#     HunterGate(
+#         URL "https://github.com/path/to/hunter/archive.tar.gz"
+#         SHA1 "798501e983f14b28b10cda16afa4de69eee1da1d"
+#     )
+#
+#     project(MyProject)
+#
+#     hunter_add_package(Foo)
+#     hunter_add_package(Boo COMPONENTS Bar Baz)
+#
+# Projects:
+#     * https://github.com/hunter-packages/gate/
+#     * https://github.com/ruslo/hunter
+
+option(HUNTER_ENABLED "Enable Hunter package manager support" ON)
+if(HUNTER_ENABLED)
+  if(CMAKE_VERSION VERSION_LESS "3.0")
+    message(FATAL_ERROR "At least CMake version 3.0 required for hunter dependency management."
+      " Update CMake or set HUNTER_ENABLED to OFF.")
+  endif()
+endif()
+
+include(CMakeParseArguments) # cmake_parse_arguments
+
+option(HUNTER_STATUS_PRINT "Print working status" ON)
+option(HUNTER_STATUS_DEBUG "Print a lot info" OFF)
+option(HUNTER_TLS_VERIFY "Enable/disable TLS certificate checking on downloads" ON)
+
+set(HUNTER_WIKI "https://github.com/ruslo/hunter/wiki")
+
+function(hunter_gate_status_print)
+  foreach(print_message ${ARGV})
+    if(HUNTER_STATUS_PRINT OR HUNTER_STATUS_DEBUG)
+      message(STATUS "[hunter] ${print_message}")
+    endif()
+  endforeach()
+endfunction()
+
+function(hunter_gate_status_debug)
+  foreach(print_message ${ARGV})
+    if(HUNTER_STATUS_DEBUG)
+      string(TIMESTAMP timestamp)
+      message(STATUS "[hunter *** DEBUG *** ${timestamp}] ${print_message}")
+    endif()
+  endforeach()
+endfunction()
+
+function(hunter_gate_wiki wiki_page)
+  message("------------------------------ WIKI -------------------------------")
+  message("    ${HUNTER_WIKI}/${wiki_page}")
+  message("-------------------------------------------------------------------")
+  message("")
+  message(FATAL_ERROR "")
+endfunction()
+
+function(hunter_gate_internal_error)
+  message("")
+  foreach(print_message ${ARGV})
+    message("[hunter ** INTERNAL **] ${print_message}")
+  endforeach()
+  message("[hunter ** INTERNAL **] [Directory:${CMAKE_CURRENT_LIST_DIR}]")
+  message("")
+  hunter_gate_wiki("error.internal")
+endfunction()
+
+function(hunter_gate_fatal_error)
+  cmake_parse_arguments(hunter "" "WIKI" "" "${ARGV}")
+  string(COMPARE EQUAL "${hunter_WIKI}" "" have_no_wiki)
+  if(have_no_wiki)
+    hunter_gate_internal_error("Expected wiki")
+  endif()
+  message("")
+  foreach(x ${hunter_UNPARSED_ARGUMENTS})
+    message("[hunter ** FATAL ERROR **] ${x}")
+  endforeach()
+  message("[hunter ** FATAL ERROR **] [Directory:${CMAKE_CURRENT_LIST_DIR}]")
+  message("")
+  hunter_gate_wiki("${hunter_WIKI}")
+endfunction()
+
+function(hunter_gate_user_error)
+  hunter_gate_fatal_error(${ARGV} WIKI "error.incorrect.input.data")
+endfunction()
+
+function(hunter_gate_self root version sha1 result)
+  string(COMPARE EQUAL "${root}" "" is_bad)
+  if(is_bad)
+    hunter_gate_internal_error("root is empty")
+  endif()
+
+  string(COMPARE EQUAL "${version}" "" is_bad)
+  if(is_bad)
+    hunter_gate_internal_error("version is empty")
+  endif()
+
+  string(COMPARE EQUAL "${sha1}" "" is_bad)
+  if(is_bad)
+    hunter_gate_internal_error("sha1 is empty")
+  endif()
+
+  string(SUBSTRING "${sha1}" 0 7 archive_id)
+
+  if(EXISTS "${root}/cmake/Hunter")
+    set(hunter_self "${root}")
+  else()
+    set(
+        hunter_self
+        "${root}/_Base/Download/Hunter/${version}/${archive_id}/Unpacked"
+    )
+  endif()
+
+  set("${result}" "${hunter_self}" PARENT_SCOPE)
+endfunction()
+
+# Set HUNTER_GATE_ROOT cmake variable to suitable value.
+function(hunter_gate_detect_root)
+  # Check CMake variable
+  string(COMPARE NOTEQUAL "${HUNTER_ROOT}" "" not_empty)
+  if(not_empty)
+    set(HUNTER_GATE_ROOT "${HUNTER_ROOT}" PARENT_SCOPE)
+    hunter_gate_status_debug("HUNTER_ROOT detected by cmake variable")
+    return()
+  endif()
+
+  # Check environment variable
+  string(COMPARE NOTEQUAL "$ENV{HUNTER_ROOT}" "" not_empty)
+  if(not_empty)
+    set(HUNTER_GATE_ROOT "$ENV{HUNTER_ROOT}" PARENT_SCOPE)
+    hunter_gate_status_debug("HUNTER_ROOT detected by environment variable")
+    return()
+  endif()
+
+  # Check HOME environment variable
+  string(COMPARE NOTEQUAL "$ENV{HOME}" "" result)
+  if(result)
+    set(HUNTER_GATE_ROOT "$ENV{HOME}/.hunter" PARENT_SCOPE)
+    hunter_gate_status_debug("HUNTER_ROOT set using HOME environment variable")
+    return()
+  endif()
+
+  # Check SYSTEMDRIVE and USERPROFILE environment variable (windows only)
+  if(WIN32)
+    string(COMPARE NOTEQUAL "$ENV{SYSTEMDRIVE}" "" result)
+    if(result)
+      set(HUNTER_GATE_ROOT "$ENV{SYSTEMDRIVE}/.hunter" PARENT_SCOPE)
+      hunter_gate_status_debug(
+          "HUNTER_ROOT set using SYSTEMDRIVE environment variable"
+      )
+      return()
+    endif()
+
+    string(COMPARE NOTEQUAL "$ENV{USERPROFILE}" "" result)
+    if(result)
+      set(HUNTER_GATE_ROOT "$ENV{USERPROFILE}/.hunter" PARENT_SCOPE)
+      hunter_gate_status_debug(
+          "HUNTER_ROOT set using USERPROFILE environment variable"
+      )
+      return()
+    endif()
+  endif()
+
+  hunter_gate_fatal_error(
+      "Can't detect HUNTER_ROOT"
+      WIKI "error.detect.hunter.root"
+  )
+endfunction()
+
+macro(hunter_gate_lock dir)
+  if(NOT HUNTER_SKIP_LOCK)
+    if("${CMAKE_VERSION}" VERSION_LESS "3.2")
+      hunter_gate_fatal_error(
+          "Can't lock, upgrade to CMake 3.2 or use HUNTER_SKIP_LOCK"
+          WIKI "error.can.not.lock"
+      )
+    endif()
+    hunter_gate_status_debug("Locking directory: ${dir}")
+    file(LOCK "${dir}" DIRECTORY GUARD FUNCTION)
+    hunter_gate_status_debug("Lock done")
+  endif()
+endmacro()
+
+function(hunter_gate_download dir)
+  string(
+      COMPARE
+      NOTEQUAL
+      "$ENV{HUNTER_DISABLE_AUTOINSTALL}"
+      ""
+      disable_autoinstall
+  )
+  if(disable_autoinstall AND NOT HUNTER_RUN_INSTALL)
+    hunter_gate_fatal_error(
+        "Hunter not found in '${dir}'"
+        "Set HUNTER_RUN_INSTALL=ON to auto-install it from '${HUNTER_GATE_URL}'"
+        "Settings:"
+        "  HUNTER_ROOT: ${HUNTER_GATE_ROOT}"
+        "  HUNTER_SHA1: ${HUNTER_GATE_SHA1}"
+        WIKI "error.run.install"
+    )
+  endif()
+  string(COMPARE EQUAL "${dir}" "" is_bad)
+  if(is_bad)
+    hunter_gate_internal_error("Empty 'dir' argument")
+  endif()
+
+  string(COMPARE EQUAL "${HUNTER_GATE_SHA1}" "" is_bad)
+  if(is_bad)
+    hunter_gate_internal_error("HUNTER_GATE_SHA1 empty")
+  endif()
+
+  string(COMPARE EQUAL "${HUNTER_GATE_URL}" "" is_bad)
+  if(is_bad)
+    hunter_gate_internal_error("HUNTER_GATE_URL empty")
+  endif()
+
+  set(done_location "${dir}/DONE")
+  set(sha1_location "${dir}/SHA1")
+
+  set(build_dir "${dir}/Build")
+  set(cmakelists "${dir}/CMakeLists.txt")
+
+  hunter_gate_lock("${dir}")
+  if(EXISTS "${done_location}")
+    # while waiting for lock other instance can do all the job
+    hunter_gate_status_debug("File '${done_location}' found, skip install")
+    return()
+  endif()
+
+  file(REMOVE_RECURSE "${build_dir}")
+  file(REMOVE_RECURSE "${cmakelists}")
+
+  file(MAKE_DIRECTORY "${build_dir}") # check directory permissions
+
+  # Disabling languages speeds up a little bit, reduces noise in the output
+  # and avoids path too long windows error
+  file(
+      WRITE
+      "${cmakelists}"
+      "cmake_minimum_required(VERSION 3.0)\n"
+      "project(HunterDownload LANGUAGES NONE)\n"
+      "include(ExternalProject)\n"
+      "ExternalProject_Add(\n"
+      "    Hunter\n"
+      "    URL\n"
+      "    \"${HUNTER_GATE_URL}\"\n"
+      "    URL_HASH\n"
+      "    SHA1=${HUNTER_GATE_SHA1}\n"
+      "    DOWNLOAD_DIR\n"
+      "    \"${dir}\"\n"
+      "    TLS_VERIFY\n"
+      "    ${HUNTER_TLS_VERIFY}\n"
+      "    SOURCE_DIR\n"
+      "    \"${dir}/Unpacked\"\n"
+      "    CONFIGURE_COMMAND\n"
+      "    \"\"\n"
+      "    BUILD_COMMAND\n"
+      "    \"\"\n"
+      "    INSTALL_COMMAND\n"
+      "    \"\"\n"
+      ")\n"
+  )
+
+  if(HUNTER_STATUS_DEBUG)
+    set(logging_params "")
+  else()
+    set(logging_params OUTPUT_QUIET)
+  endif()
+
+  hunter_gate_status_debug("Run generate")
+
+  # Need to add toolchain file too.
+  # Otherwise on Visual Studio + MDD this will fail with error:
+  # "Could not find an appropriate version of the Windows 10 SDK installed on this machine"
+  if(EXISTS "${CMAKE_TOOLCHAIN_FILE}")
+    get_filename_component(absolute_CMAKE_TOOLCHAIN_FILE "${CMAKE_TOOLCHAIN_FILE}" ABSOLUTE)
+    set(toolchain_arg "-DCMAKE_TOOLCHAIN_FILE=${absolute_CMAKE_TOOLCHAIN_FILE}")
+  else()
+    # 'toolchain_arg' can't be empty
+    set(toolchain_arg "-DCMAKE_TOOLCHAIN_FILE=")
+  endif()
+
+  string(COMPARE EQUAL "${CMAKE_MAKE_PROGRAM}" "" no_make)
+  if(no_make)
+    set(make_arg "")
+  else()
+    # Test case: remove Ninja from PATH but set it via CMAKE_MAKE_PROGRAM
+    set(make_arg "-DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}")
+  endif()
+
+  execute_process(
+      COMMAND
+      "${CMAKE_COMMAND}"
+      "-H${dir}"
+      "-B${build_dir}"
+      "-G${CMAKE_GENERATOR}"
+      "${toolchain_arg}"
+      ${make_arg}
+      WORKING_DIRECTORY "${dir}"
+      RESULT_VARIABLE download_result
+      ${logging_params}
+  )
+
+  if(NOT download_result EQUAL 0)
+    hunter_gate_internal_error("Configure project failed")
+  endif()
+
+  hunter_gate_status_print(
+      "Initializing Hunter workspace (${HUNTER_GATE_SHA1})"
+      "  ${HUNTER_GATE_URL}"
+      "  -> ${dir}"
+  )
+  execute_process(
+      COMMAND "${CMAKE_COMMAND}" --build "${build_dir}"
+      WORKING_DIRECTORY "${dir}"
+      RESULT_VARIABLE download_result
+      ${logging_params}
+  )
+
+  if(NOT download_result EQUAL 0)
+    hunter_gate_internal_error("Build project failed")
+  endif()
+
+  file(REMOVE_RECURSE "${build_dir}")
+  file(REMOVE_RECURSE "${cmakelists}")
+
+  file(WRITE "${sha1_location}" "${HUNTER_GATE_SHA1}")
+  file(WRITE "${done_location}" "DONE")
+
+  hunter_gate_status_debug("Finished")
+endfunction()
+
+# Must be a macro so master file 'cmake/Hunter' can
+# apply all variables easily just by 'include' command
+# (otherwise PARENT_SCOPE magic needed)
+macro(HunterGate)
+  if(HUNTER_GATE_DONE)
+    # variable HUNTER_GATE_DONE set explicitly for external project
+    # (see `hunter_download`)
+    set_property(GLOBAL PROPERTY HUNTER_GATE_DONE YES)
+  endif()
+
+  # First HunterGate command will init Hunter, others will be ignored
+  get_property(_hunter_gate_done GLOBAL PROPERTY HUNTER_GATE_DONE SET)
+
+  if(NOT HUNTER_ENABLED)
+    # Empty function to avoid error "unknown function"
+    function(hunter_add_package)
+    endfunction()
+
+    set(
+        _hunter_gate_disabled_mode_dir
+        "${CMAKE_CURRENT_LIST_DIR}/cmake/Hunter/disabled-mode"
+    )
+    if(EXISTS "${_hunter_gate_disabled_mode_dir}")
+      hunter_gate_status_debug(
+          "Adding \"disabled-mode\" modules: ${_hunter_gate_disabled_mode_dir}"
+      )
+      list(APPEND CMAKE_PREFIX_PATH "${_hunter_gate_disabled_mode_dir}")
+    endif()
+  elseif(_hunter_gate_done)
+    hunter_gate_status_debug("Secondary HunterGate (use old settings)")
+    hunter_gate_self(
+        "${HUNTER_CACHED_ROOT}"
+        "${HUNTER_VERSION}"
+        "${HUNTER_SHA1}"
+        _hunter_self
+    )
+    include("${_hunter_self}/cmake/Hunter")
+  else()
+    set(HUNTER_GATE_LOCATION "${CMAKE_CURRENT_LIST_DIR}")
+
+    string(COMPARE NOTEQUAL "${PROJECT_NAME}" "" _have_project_name)
+    if(_have_project_name)
+      hunter_gate_fatal_error(
+          "Please set HunterGate *before* 'project' command. "
+          "Detected project: ${PROJECT_NAME}"
+          WIKI "error.huntergate.before.project"
+      )
+    endif()
+
+    cmake_parse_arguments(
+        HUNTER_GATE "LOCAL" "URL;SHA1;GLOBAL;FILEPATH" "" ${ARGV}
+    )
+
+    string(COMPARE EQUAL "${HUNTER_GATE_SHA1}" "" _empty_sha1)
+    string(COMPARE EQUAL "${HUNTER_GATE_URL}" "" _empty_url)
+    string(
+        COMPARE
+        NOTEQUAL
+        "${HUNTER_GATE_UNPARSED_ARGUMENTS}"
+        ""
+        _have_unparsed
+    )
+    string(COMPARE NOTEQUAL "${HUNTER_GATE_GLOBAL}" "" _have_global)
+    string(COMPARE NOTEQUAL "${HUNTER_GATE_FILEPATH}" "" _have_filepath)
+
+    if(_have_unparsed)
+      hunter_gate_user_error(
+          "HunterGate unparsed arguments: ${HUNTER_GATE_UNPARSED_ARGUMENTS}"
+      )
+    endif()
+    if(_empty_sha1)
+      hunter_gate_user_error("SHA1 suboption of HunterGate is mandatory")
+    endif()
+    if(_empty_url)
+      hunter_gate_user_error("URL suboption of HunterGate is mandatory")
+    endif()
+    if(_have_global)
+      if(HUNTER_GATE_LOCAL)
+        hunter_gate_user_error("Unexpected LOCAL (already has GLOBAL)")
+      endif()
+      if(_have_filepath)
+        hunter_gate_user_error("Unexpected FILEPATH (already has GLOBAL)")
+      endif()
+    endif()
+    if(HUNTER_GATE_LOCAL)
+      if(_have_global)
+        hunter_gate_user_error("Unexpected GLOBAL (already has LOCAL)")
+      endif()
+      if(_have_filepath)
+        hunter_gate_user_error("Unexpected FILEPATH (already has LOCAL)")
+      endif()
+    endif()
+    if(_have_filepath)
+      if(_have_global)
+        hunter_gate_user_error("Unexpected GLOBAL (already has FILEPATH)")
+      endif()
+      if(HUNTER_GATE_LOCAL)
+        hunter_gate_user_error("Unexpected LOCAL (already has FILEPATH)")
+      endif()
+    endif()
+
+    hunter_gate_detect_root() # set HUNTER_GATE_ROOT
+
+    # Beautify path, fix probable problems with windows path slashes
+    get_filename_component(
+        HUNTER_GATE_ROOT "${HUNTER_GATE_ROOT}" ABSOLUTE
+    )
+    hunter_gate_status_debug("HUNTER_ROOT: ${HUNTER_GATE_ROOT}")
+    if(NOT HUNTER_ALLOW_SPACES_IN_PATH)
+      string(FIND "${HUNTER_GATE_ROOT}" " " _contain_spaces)
+      if(NOT _contain_spaces EQUAL -1)
+        hunter_gate_fatal_error(
+            "HUNTER_ROOT (${HUNTER_GATE_ROOT}) contains spaces."
+            "Set HUNTER_ALLOW_SPACES_IN_PATH=ON to skip this error"
+            "(Use at your own risk!)"
+            WIKI "error.spaces.in.hunter.root"
+        )
+      endif()
+    endif()
+
+    string(
+        REGEX
+        MATCH
+        "[0-9]+\\.[0-9]+\\.[0-9]+[-_a-z0-9]*"
+        HUNTER_GATE_VERSION
+        "${HUNTER_GATE_URL}"
+    )
+    string(COMPARE EQUAL "${HUNTER_GATE_VERSION}" "" _is_empty)
+    if(_is_empty)
+      set(HUNTER_GATE_VERSION "unknown")
+    endif()
+
+    hunter_gate_self(
+        "${HUNTER_GATE_ROOT}"
+        "${HUNTER_GATE_VERSION}"
+        "${HUNTER_GATE_SHA1}"
+        _hunter_self
+    )
+
+    set(_master_location "${_hunter_self}/cmake/Hunter")
+    if(EXISTS "${HUNTER_GATE_ROOT}/cmake/Hunter")
+      # Hunter downloaded manually (e.g. by 'git clone')
+      set(_unused "xxxxxxxxxx")
+      set(HUNTER_GATE_SHA1 "${_unused}")
+      set(HUNTER_GATE_VERSION "${_unused}")
+    else()
+      get_filename_component(_archive_id_location "${_hunter_self}/.." ABSOLUTE)
+      set(_done_location "${_archive_id_location}/DONE")
+      set(_sha1_location "${_archive_id_location}/SHA1")
+
+      # Check Hunter already downloaded by HunterGate
+      if(NOT EXISTS "${_done_location}")
+        hunter_gate_download("${_archive_id_location}")
+      endif()
+
+      if(NOT EXISTS "${_done_location}")
+        hunter_gate_internal_error("hunter_gate_download failed")
+      endif()
+
+      if(NOT EXISTS "${_sha1_location}")
+        hunter_gate_internal_error("${_sha1_location} not found")
+      endif()
+      file(READ "${_sha1_location}" _sha1_value)
+      string(COMPARE EQUAL "${_sha1_value}" "${HUNTER_GATE_SHA1}" _is_equal)
+      if(NOT _is_equal)
+        hunter_gate_internal_error(
+            "Short SHA1 collision:"
+            "  ${_sha1_value} (from ${_sha1_location})"
+            "  ${HUNTER_GATE_SHA1} (HunterGate)"
+        )
+      endif()
+      if(NOT EXISTS "${_master_location}")
+        hunter_gate_user_error(
+            "Master file not found:"
+            "  ${_master_location}"
+            "try to update Hunter/HunterGate"
+        )
+      endif()
+    endif()
+    include("${_master_location}")
+    set_property(GLOBAL PROPERTY HUNTER_GATE_DONE YES)
+  endif()
+endmacro()

--- a/cmake/hunter.cmake
+++ b/cmake/hunter.cmake
@@ -1,0 +1,6 @@
+option(HUNTER_ENABLED "Enable Hunter package manager support" OFF)
+include("cmake/HunterGate.cmake")
+HunterGate(
+    URL "https://github.com/ruslo/hunter/archive/v0.20.27.tar.gz"
+    SHA1 "aafefc6377dc9a25d84703702e22434cd6f71d5c"
+)

--- a/cmake/toolchain.cmake
+++ b/cmake/toolchain.cmake
@@ -1,0 +1,7 @@
+# Encapsulate all global definitions as an optional/convenient "pseudo"-toolchain
+# while allowing user to define a custom global shared toolchain.
+add_definitions(-Wall -Wextra -Wno-unused-function)
+add_definitions(-fPIC)
+add_definitions(-Ofast)
+add_definitions(-ffast-math)
+add_definitions(-fvisibility=hidden -fvisibility-inlines-hidden)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,16 +1,12 @@
-
-find_package(OpenCV QUIET COMPONENTS core highgui imgproc imgcodecs)
-if(NOT OpenCV_FOUND)
-    find_package(OpenCV REQUIRED COMPONENTS core highgui imgproc)
-endif()
-
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../src)
-include_directories(${CMAKE_CURRENT_BINARY_DIR}/../src)
+hunter_add_package(OpenCV)
+find_package(OpenCV REQUIRED)
 
 add_executable(squeezenet squeezenet.cpp)
 target_link_libraries(squeezenet ncnn ${OpenCV_LIBS})
+install(TARGETS squeezenet DESTINATION bin)
 
 add_executable(fasterrcnn fasterrcnn.cpp)
 target_link_libraries(fasterrcnn ncnn ${OpenCV_LIBS})
+install(TARGETS fasterrcnn DESTINATION bin)
 
 add_subdirectory(ssd)

--- a/examples/ssd/CMakeLists.txt
+++ b/examples/ssd/CMakeLists.txt
@@ -1,14 +1,9 @@
-find_package(OpenCV REQUIRED core highgui )
-
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../src)
-include_directories(${CMAKE_CURRENT_BINARY_DIR}/../../src)
-
-
-
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
+find_package(OpenCV REQUIRED)
 
 add_executable(ssdmobilenet ssdmobilenet.cpp)
 target_link_libraries(ssdmobilenet ncnn ${OpenCV_LIBS})
+install(TARGETS ssdmobilenet DESTINATION bin)
 
 add_executable(ssdsqueezenet ssdsqueezenet.cpp)
 target_link_libraries(ssdsqueezenet ncnn ${OpenCV_LIBS})
+install(TARGETS ssdsqueezenet DESTINATION bin)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,12 +1,6 @@
-
 ##############################################
 
 configure_file(platform.h.in ${CMAKE_CURRENT_BINARY_DIR}/platform.h)
-
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/layer)
-
 set(ncnn_SRCS
     blob.cpp
     cpu.cpp
@@ -143,9 +137,64 @@ ncnn_add_layer(DeconvolutionDepthWise)
 ncnn_add_layer(ShuffleChannel)
 ncnn_add_layer(InstanceNorm)
 
-add_library(ncnn STATIC ${ncnn_SRCS})
+add_library(ncnn ${ncnn_SRCS})
+target_include_directories(ncnn 
+  PUBLIC # these will be propagated to dependencies
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/layer>"
+)
 
-install(TARGETS ncnn ARCHIVE DESTINATION lib)
+# Installation (https://github.com/forexample/package-example) {
+
+# Layout. This works for all platforms:
+#   * <prefix>/lib/cmake/<PROJECT-NAME>
+#   * <prefix>/lib/
+#   * <prefix>/include/
+set(config_install_dir "lib/cmake/${PROJECT_NAME}")
+set(include_install_dir "include")
+
+set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
+
+# Configuration
+set(version_config "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
+set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
+set(namespace "${PROJECT_NAME}::")
+
+# Include module with fuction 'write_basic_package_version_file'
+include(CMakePackageConfigHelpers)
+
+# Configure '<PROJECT-NAME>ConfigVersion.cmake'
+# Use:
+#   * PROJECT_VERSION
+write_basic_package_version_file(
+    "${version_config}" COMPATIBILITY SameMajorVersion
+)
+
+# Configure '<PROJECT-NAME>Config.cmake'
+# Use variables:
+#   * TARGETS_EXPORT_NAME
+#   * PROJECT_NAME
+configure_package_config_file(
+    "${NCNN_TOP_DIR}/cmake/Config.cmake.in"
+    "${project_config}"
+    INSTALL_DESTINATION "${config_install_dir}"
+)
+
+# Targets:
+#   * header location after install: <prefix>/include/ncnn/ncnn.hpp
+#   * headers can be included by C++ code `#include <ncnn/ncnn.hpp>`
+install(
+    TARGETS ncnn
+    EXPORT "${TARGETS_EXPORT_NAME}"
+    LIBRARY DESTINATION "lib"
+    ARCHIVE DESTINATION "lib"
+    RUNTIME DESTINATION "bin"
+    INCLUDES DESTINATION "${include_install_dir}"
+)
+
+# Headers:
+#   * include/ncnn/ncnn.hpp -> <prefix>/include/ncnn/ncnn.hpp
 install(FILES
     blob.h
     cpu.h
@@ -159,5 +208,23 @@ install(FILES
     benchmark.h
     ${CMAKE_CURRENT_BINARY_DIR}/layer_type_enum.h
     ${CMAKE_CURRENT_BINARY_DIR}/platform.h
-    DESTINATION include
+    DESTINATION "${include_install_dir}"
 )
+
+# Config
+#   * <prefix>/lib/cmake/ncnn/ncnnConfig.cmake
+#   * <prefix>/lib/cmake/ncnn/ncnnConfigVersion.cmake
+install(
+    FILES "${project_config}" "${version_config}"
+    DESTINATION "${config_install_dir}"
+)
+
+# Config
+#   * <prefix>/lib/cmake/ncnn/ncnnTargets.cmake
+install(
+    EXPORT "${TARGETS_EXPORT_NAME}"
+    NAMESPACE "${namespace}"
+    DESTINATION "${config_install_dir}"
+)
+
+# }

--- a/src/mat.h
+++ b/src/mat.h
@@ -15,6 +15,7 @@
 #ifndef NCNN_MAT_H
 #define NCNN_MAT_H
 
+#include <string>
 #include <stdlib.h>
 #include <string.h>
 #if __ARM_NEON

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,12 +1,6 @@
-
 add_subdirectory(caffe)
 add_subdirectory(mxnet)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../src)
-include_directories(${CMAKE_CURRENT_BINARY_DIR}/../src)
-
-include_directories(${CMAKE_SOURCE_DIR}/src)
-
 add_executable(ncnn2mem ncnn2mem.cpp)
-
 target_link_libraries(ncnn2mem ncnn)
+install(TARGETS ncnn2mem EXPORT ${TARGETS_EXPORT_NAME} DESTINATION bin COMPONENT bin)

--- a/tools/caffe/CMakeLists.txt
+++ b/tools/caffe/CMakeLists.txt
@@ -1,11 +1,16 @@
+# Compatibility Mode introduced by protobuf
+# * see examples/Protobuf for usage of protobuf_MODULE_COMPATIBLE=OFF
+option(protobuf_MODULE_COMPATIBLE "use protobuf in module compatible mode" ON)
+hunter_add_package(Protobuf)
+find_package(Protobuf CONFIG REQUIRED)
 
-find_package(Protobuf REQUIRED)
-
-include_directories(${PROTOBUF_INCLUDE_DIR})
-
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
 protobuf_generate_cpp(CAFFE_PROTO_SRCS CAFFE_PROTO_HDRS caffe.proto)
 
 add_executable(caffe2ncnn caffe2ncnn.cpp ${CAFFE_PROTO_SRCS} ${CAFFE_PROTO_HDRS})
+target_include_directories(caffe2ncnn
+  PUBLIC # For generated files
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>"
+)
 
-target_link_libraries(caffe2ncnn ${PROTOBUF_LIBRARIES})
+target_link_libraries(caffe2ncnn protobuf::libprotobuf)
+install(TARGETS caffe2ncnn EXPORT ${TARGETS_EXPORT_NAME} DESTINATION bin COMPONENT bin)

--- a/tools/mxnet/CMakeLists.txt
+++ b/tools/mxnet/CMakeLists.txt
@@ -1,2 +1,2 @@
-
 add_executable(mxnet2ncnn mxnet2ncnn.cpp)
+install(TARGETS mxnet2ncnn EXPORT ${TARGETS_EXPORT_NAME} DESTINATION bin COMPONENT bin)


### PR DESCRIPTION
CMake updates:
* add HunterGate in optional cmake/hunter.cmake include
* add cmake generated package configuration installation w/ boilerplate from https://github.com/forexample/package-example
* add pseudo semantic version 2018.03.14 to match release style
* add options to control what/how to build
  + NCNN_BUILD_EXAMPLES: toggle examples
  + NCNN_BUILD_BENCHMARK: processing benchmnark
  + NCNN_BUILD_TOOLS: network conversion tools X-to-ncnn
  + NCNN_BUILD_TOOLCHAIN: make the local compiler flag definitions optional to allow clean use of user provided toolchain that may have conflicting options — default options are consolidated in cmake/toolchain.cmake file
* add version check for OpenMP (requies collapse, which is >= 3.0)
* replace global  include_directories w/ target_include_directories
* add hunter_add_package() for protobuf and opencv dependencies in tools/examples
* add explicit install() step for libs + executables
* add multi-toolchain travis and appveyor config files w/ simple bash and CMD scripts to install requirements on *nix and windows platforms