### PR TITLE
fix cmake openmp usage and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
-# source: https://raw.githubusercontent.com/ingenue/hunter/pkg.template/.travis.yml
-
 # OSX/Linux (https://github.com/travis-ci-tester/toolchain-table)
 
 # Workaround for https://github.com/travis-ci/travis-ci/issues/8363
 language:
-  - minimal
+  - cpp
 
 # Container-based infrastructure (Linux)
 # * https://docs.travis-ci.com/user/migrating-from-legacy/#How-can-I-use-container-based-infrastructure%3F
@@ -13,16 +11,17 @@ sudo:
 
 # Install packages differs for container-based infrastructure
 # * https://docs.travis-ci.com/user/migrating-from-legacy/#How-do-I-install-APT-sources-and-packages%3F
+# List of available packages:
+# * https://github.com/travis-ci/apt-package-whitelist/blob/master/ubuntu-trusty
+# List of available sources:
+# * https://github.com/travis-ci/apt-source-whitelist/blob/master/ubuntu.json
 addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-      - llvm-toolchain-trusty-5.0
     packages:
       - python3-pip
-
-      - g++-5
-      - gcc-5
+      - g++-7
 
 dist:
   - trusty
@@ -34,17 +33,15 @@ matrix:
     - os: linux
       env: CONFIG=Release TOOLCHAIN=clang-cxx17
 
-    # FIXME: https://travis-ci.org/xsacha/hunter/jobs/347083573
-    # - os: linux
-    #   env: CONFIG=Release TOOLCHAIN=gcc-7-cxx17 
+    - os: linux
+      env: CONFIG=Release TOOLCHAIN=gcc-7-cxx17
 
     - os: linux
-      env: CONFIG=Release TOOLCHAIN=android-ndk-r16b-api-24-arm64-v8a-clang-libcxx14 
+      env: CONFIG=Release TOOLCHAIN=android-ndk-r16b-api-24-arm64-v8a-clang-libcxx14
 
-    # FIXME (TIFF broken)
-    # * https://travis-ci.org/ingenue/hunter/jobs/116592968
-    # - os: linux
-    #   env: CONFIG=Release TOOLCHAIN=analyze-cxx17
+# Various errors
+#    - os: linux
+#      env: CONFIG=Release TOOLCHAIN=analyze-cxx17
 
     - os: linux
       env: CONFIG=Release TOOLCHAIN=sanitize-address-cxx17
@@ -53,7 +50,7 @@ matrix:
       env: CONFIG=Release TOOLCHAIN=sanitize-leak-cxx17
 
     - os: linux
-      env: CONFIG=Release TOOLCHAIN=sanitize-thread-cxx17 
+      env: CONFIG=Release TOOLCHAIN=sanitize-thread-cxx17
 
     # }
 
@@ -65,104 +62,16 @@ matrix:
 
     - os: osx
       osx_image: xcode9.2
-      env: CONFIG=Release TOOLCHAIN=osx-10-13-cxx14 
+      env: CONFIG=Release TOOLCHAIN=osx-10-13-cxx14
 
-    # Upload from local machine
-    # FIXME: modules/core/src/parallel_impl.cpp:396:21: error: implicitly declaring library function '_mm_pause' with type 'void ()'
-    # - os: osx
-    #   osx_image: xcode9.2
-    #   env: CONFIG=Release TOOLCHAIN=ios-nocodesign-11-2-dep-9-3 
+    - os: osx
+      osx_image: xcode9.2
+      env: CONFIG=Release TOOLCHAIN=ios-nocodesign-11-2-dep-9-3
 
     # }
-
-    # OpenCV-extra {
-
-    # Linux {
-
-    - os: linux
-      env: CONFIG=Release-extra TOOLCHAIN=clang-cxx17 
-
-    # FIXME: https://travis-ci.org/xsacha/hunter/jobs/347083589
-    # - os: linux
-    #   env: CONFIG=Release-extra TOOLCHAIN=gcc-7-cxx17
-
-    - os: linux
-      env: CONFIG=Release-extra TOOLCHAIN=android-ndk-r16b-api-24-arm64-v8a-clang-libcxx14 
-
-    # FIXME (TIFF broken)
-    # * https://travis-ci.org/ingenue/hunter/jobs/116592968
-    # - os: linux
-    #   env: CONFIG=Release-extra TOOLCHAIN=analyze-cxx17
-
-    - os: linux
-      env: CONFIG=Release-extra TOOLCHAIN=sanitize-address-cxx17 
-
-    - os: linux
-      env: CONFIG=Release-extra TOOLCHAIN=sanitize-leak-cxx17 
-
-    - os: linux
-      env: CONFIG=Release-extra TOOLCHAIN=sanitize-thread-cxx17 
-
-    # }
-
-    # OSX {
-
-    - os: osx
-      osx_image: xcode9.2
-      env: CONFIG=Release-extra TOOLCHAIN=osx-10-13-make-cxx14
-
-    - os: osx
-      osx_image: xcode9.2
-      env: CONFIG=Release-extra TOOLCHAIN=osx-10-13-cxx14 
-
-    # Upload from local machine
-    # FIXME: modules/core/src/parallel_impl.cpp:396:21: error: implicitly declaring library function '_mm_pause' with type 'void ()'
-    # - os: osx
-    #   osx_image: xcode9.2
-    #   env: CONFIG=Release-extra TOOLCHAIN=ios-nocodesign-11-2-dep-9-3 
-
-    # }
-
-    # }
-
-    # Extra {
-
-    # FIXME: https://travis-ci.org/xsacha/hunter/jobs/347083580
-    # - os: linux
-    #   env: CONFIG=Release-Qt TOOLCHAIN=gcc-7-cxx17 
-
-    - os: osx
-      osx_image: xcode9.2
-      env: CONFIG=Release TOOLCHAIN=ios-nocodesign-11-2-dep-9-3-armv7 
-
-    - os: osx
-      osx_image: xcode9.2
-      env: CONFIG=Release TOOLCHAIN=ios-nocodesign-11-2-dep-9-3-arm64 
-
-    - os: osx
-      osx_image: xcode9.2
-      env: CONFIG=Release-extra TOOLCHAIN=ios-nocodesign-11-2-dep-9-3-armv7 
-
-    # Upload from local machine
-    - os: osx
-      osx_image: xcode9.2
-      env: CONFIG=Release-extra TOOLCHAIN=ios-nocodesign-11-2-dep-9-3-arm64 
-
-    # }
-
 
 install:
   - source bin/hunter_env.sh
 
 script:
   - polly.py --toolchain ${TOOLCHAIN} --config ${CONFIG} --verbose --fwd HUNTER_SUPPRESS_LIST_OF_FILES=ON NCNN_LOCAL_TOOLCHAIN=OFF ${TEST} --install --discard 10 --tail 200
-  
-# https://docs.travis-ci.com/user/customizing-the-build/#Whitelisting-or-blacklisting-branches
-# Exclude branch 'pkg.template'. Nothing to build there.
-branches:
-  except:
-    - pkg.template
-    - /^pr\..*/
-    - /^v[0-9]+\.[0-9]+\.[0-9]+$/
-
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,14 +14,6 @@ option(NCNN_BUILD_BENCHMARK "build the benchmarks" OFF)
 option(NCNN_BUILD_TOOLS "build ncnn tools" OFF)
 option(NCNN_LOCAL_TOOLCHAIN "use internal default compiler flags" ON)
 
-if(NCNN_OPENMP)
-    find_package(OpenMP) # >= 3.0 for 'collapse'
-    if((OpenMP_CXX_FOUND OR OPENMP_FOUND) AND OpenMP_CXX_VERSION_MAJOR GREATER_EQUAL 3.0)
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-    endif()
-endif()
-
 if(NCNN_LOCAL_TOOLCHAIN)
   include(cmake/toolchain.cmake)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -145,6 +145,14 @@ target_include_directories(ncnn
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/layer>"
 )
 
+if(NCNN_OPENMP)
+    find_package(OpenMP) # >= 3.0 for 'collapse'
+    if((OpenMP_CXX_FOUND OR OPENMP_FOUND) AND OpenMP_CXX_VERSION_MAJOR GREATER_EQUAL 3.0)
+        target_compile_options(ncnn PUBLIC ${OpenMP_CXX_FLAGS})
+        target_link_libraries(ncnn PUBLIC ${OpenMP_CXX_FLAGS})
+    endif()
+endif()
+
 # Installation (https://github.com/forexample/package-example) {
 
 # Layout. This works for all platforms:


### PR DESCRIPTION
* use target_compile_options and target_link_libraries to apply OpenMP_CXX_FLAGS
* update travis to match latest hunter toolchains (exclude static analyzer)